### PR TITLE
クエスト一覧関連ページの機能の追加、変更

### DIFF
--- a/app/front/quest-list-detail.php
+++ b/app/front/quest-list-detail.php
@@ -1,10 +1,14 @@
 <?php require_once("./header.php"); ?>
-
 <?php
-    $getQuestId = $_GET['id'];
-    $result = getQuestListDetail($getQuestId);
-?>
+$getQuestId = $_GET['id'];
+$questInfo = getQuestListDetail($getQuestId);
 
+if (array_key_exists('start', $_POST)) {
+    $startTime = startRecordsForQuest($getQuestId);
+} elseif (array_key_exists('stop', $_POST)) {
+    finishedRecordsForQuest($getId, $startedTime);
+}
+?>
 
 <div class="c-wrapper">
     <div class="c-nav-breadcrumb">
@@ -37,8 +41,10 @@
             ?>
             <div class="p-quest-detail__time-measure">
                 <div class="p-quest-detail__time-measure-wrap">
-                    <button id="js-stopwatchStart" type="button"><img src="./img/icon/play.png" alt="再生ボタン" width="40px" height="40px"></button>
-                    <button id="js-stopwatchStop" type="button"><img src="./img/icon/stop.png" alt="停止ボタン" width="40px" height="40px"></button>
+                    <form action="" method="post">
+                        <button id="js-stopwatchStart" type="submit" name="start"><img src="./img/icon/play.png" alt="再生ボタン" width="40px" height="40px"></button>
+                        <button id="js-stopwatchStop" type="submit" name="stop"><img src="./img/icon/stop.png" alt="停止ボタン" width="40px" height="40px"></button>
+                    </form>
                     <div class="p-quest-detail__time-measure-result">
                         <time id="js-stopwatch" date-time="00:00:00">00:00:00</time>
                     </div>

--- a/app/front/quest-list.php
+++ b/app/front/quest-list.php
@@ -1,6 +1,7 @@
 <?php require_once("./header.php"); ?>
 
 <?php $phpQuestList = getQuestList(4);?>
+<?php $dbQuestList = getQuestList(6);?>
 
 <div class="c-wrapper">
     <div class="c-nav-breadcrumb">

--- a/app/php/quests.php
+++ b/app/php/quests.php
@@ -2,30 +2,51 @@
 
 function getQuestList($teq_category_id)
 {
-    $count = 0;
     $beforeStr = array("1", "2", "3", "4", "5", "6", "7", "8", "9","10", "11", "12", "13", "14", "15");
     $afterStr = array("i", "ii", "iii", "iv", "v", "vi", "vii", "viii", "ix","x", "xi", "xii", "xiii", "xiv", "xv");
     $pdo = dbConnect();
 
     try {
         //クエスト一覧を取得
-        $query = 'SELECT quest_no, quest_title, if_advanced FROM quests WHERE teq_category_id = :teq_category_id';
+        $query = <<<EOT
+            SELECT que.quest_no ,
+                   que.quest_title,
+                   que.if_advanced,
+                   teq.category_name AS teqName,
+                   que_category.category_name AS queName
+            FROM quests AS que
+            INNER JOIN teq_categorys AS teq
+            ON que.teq_category_id = teq.category_id
+            INNER JOIN quest_categorys AS que_category
+            ON que.quest_category_id = que_category.category_id
+            WHERE que.teq_category_id = :teq_category_id
+        EOT;
         $statement = $pdo->prepare($query);
         $statement->bindValue(':teq_category_id', $teq_category_id, PDO::PARAM_INT);
         $statement->execute();
+        $results = $statement->fetchAll(PDO::FETCH_ASSOC);
 
-        while ($result = $statement->fetch(PDO::FETCH_ASSOC)) {
-            //カラムquest_titleのデータを上から1レコードずつ、配列に格納
+        foreach ($results as $key => $result) {
+            //配列イメージ
+            // $questList = [
+            //     $teqName => [
+            //         $queName => [
+            //            $questNo => quest_title
+            //         ]
+            //     ]
+            // ];
+            $teqName = $result['teqName'];
+            $queName = $result['queName'];
+            $questNo = $result['quest_no'];
             $replaceStr = str_replace($beforeStr, $afterStr, $result['quest_no']);
             if ($result['if_advanced'] === "1") {
-                $row[$count] = "QUEST " . $replaceStr . " " . $result['quest_title'] . "(advanced)";
+                $questList[$teqName][$queName][$questNo] = "QUEST " . $replaceStr . " " . $result['quest_title'] . "(advanced)";
             } else {
-                $row[$count] = "QUEST " . $replaceStr . " " . $result['quest_title'];
+                $questList[$teqName][$queName][$questNo] = "QUEST " . $replaceStr . " " . $result['quest_title'];
             }
-            $count++;
         }
 
-        return $row;
+        return $questList;
     } catch (PDOException $e) {
         echo "取得失敗";
         return $e;
@@ -59,7 +80,6 @@ function getQuestListDetail($getQuestId)
         $statement->bindValue(':quest_id', $getQuestId, PDO::PARAM_INT);
         $statement->execute();
         $result = $statement->fetch(PDO::FETCH_ASSOC);
-        // print_r($result);
 
         $teqCategoryName = $result['teqName'];
         $questCategoryName = $result['queName'];
@@ -70,13 +90,13 @@ function getQuestListDetail($getQuestId)
             $row = "QUEST " . $replaceStr . " " . $result['quest_title'];
         }
 
-        $array = [
+        $questInfo = [
             $teqCategoryName => [
                 $questCategoryName => $row
             ]
         ];
 
-        return $array;
+        return $questInfo;
     } catch (PDOException $e) {
         echo "取得失敗";
         return $e;


### PR DESCRIPTION
    変更内容：
    ・クエスト詳細情報を取得する変数名を変更(quest-list-detail.php $result -> $questInfo)
    ・POST送信でクエスト学習時間を記録する処理を追加(quest-list-detail.php)
    ・クエスト学習時間を記録する関数(startRecordsForQuest(), finishedRecordsForQuest())を追加(records.php)
    ・クエスト一覧にDBクエストリストを取得する処理を追加(quest-list.php)
    ・クエスト一覧情報を取得する処理をキーを含む配列に格納するよう修正(quests.php)
    ・誤記修正、不要な行削除(quests.php)